### PR TITLE
Fixes retry logic for rtorrent instance connection failures

### DIFF
--- a/server/middleware/clientActivityStream.js
+++ b/server/middleware/clientActivityStream.js
@@ -59,6 +59,10 @@ module.exports = (req, res) => {
     serverEvent.emit();
   });
 
+  if (serviceInstances.clientGatewayService.hasError) {
+    serviceInstances.clientGatewayService.testGateway();
+  }
+
   // TODO: Handle empty or sub-optimal history states.
   // Get user's specified history snapshot current history.
   serviceInstances.historyService.getHistory({snapshot: historySnapshot}, (snapshot, error) => {

--- a/server/services/torrentService.js
+++ b/server/services/torrentService.js
@@ -238,7 +238,7 @@ class TorrentService extends BaseService {
     // If more than consecutive errors have occurred, then we delay the next
     // request.
     if (++this.errorCount >= 3) {
-      nextInterval = Math.max(nextInterval + (this.errorCount * nextInterval) / 4, 1000 * 60);
+      nextInterval = Math.min(nextInterval + 2 ** this.errorCount, 1000 * 60);
     }
 
     this.deferFetchTorrentList(nextInterval);


### PR DESCRIPTION
## Description
Fixes a bug where Flood wouldn't re-establish connection to rtorrent instance after the instance became unavailable.

Also fixed the backoff duration for retrying connections to rtorrent.

## Related Issue
Fixes https://github.com/Flood-UI/flood/issues/789
Fixes https://github.com/Flood-UI/flood/issues/790

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
