### PR TITLE
SCGI: Fix Promise Rejection

### DIFF
--- a/server/util/scgiUtil.js
+++ b/server/util/scgiUtil.js
@@ -23,7 +23,8 @@ const methodCall = (connectionMethod, methodName, parameters) =>
     const stream = net.connect(networkConfiguration);
     const xml = Serializer.serializeMethodCall(methodName, parameters);
     const xmlLength = Buffer.byteLength(xml, 'utf8');
-
+  
+    stream.on('error', reject);
     stream.setEncoding('UTF8');
 
     const headerItems = [`CONTENT_LENGTH${NULL_CHAR}${xmlLength}${NULL_CHAR}`, `SCGI${NULL_CHAR}1${NULL_CHAR}`];
@@ -34,7 +35,7 @@ const methodCall = (connectionMethod, methodName, parameters) =>
 
     bufferStream(stream).then(data => {
       rTorrentDeserializer.deserialize(data, resolve, reject);
-    });
+    }).catch(err => reject(err));
   });
 
 module.exports = {methodCall};


### PR DESCRIPTION
## Description
* Fixes bug where if you specify an incorrect server connection it loads a blank flood page
* Fixes one of the unhandled promise rejection errors (There's still one more that I can't narrow down)
* `net.connect` seems like it might throw other errors so this may be better suited in a try / catch block? or a node.js domain?

## Related Issue
N/A. Let me know if you want me to open one.

