### PR TITLE
Lower Memory Footprint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6944,13 +6944,14 @@
         "globule": "^1.0.0"
       }
     },
-    "geoip-lite": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/geoip-lite/-/geoip-lite-1.3.7.tgz",
-      "integrity": "sha512-hdlRVXTk/cFFXbeDl0KdcDSH2Gzlyp7050Q+ml+g9Y0BkygjDklwF/nKcouzHWWzPsBRIp0EJXiKaTqJ0hlDSQ==",
+    "geoip-country": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/geoip-country/-/geoip-country-3.2.2.tgz",
+      "integrity": "sha512-o8YHDLzmKemULA1R8SAklI3KHL3kpMpzWuY9m3PgwM9G4QktA8RcrIq59noawpkUxJQiF0ZKsMM1crqr0weTQg==",
       "requires": {
         "async": "^2.1.1",
         "colors": "^1.1.2",
+        "glob": "^7.1.1",
         "iconv-lite": "^0.4.13",
         "ip-address": "^5.8.9",
         "lazy": "^1.0.11",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format-source": "node scripts/prettier.js format",
     "check-source-formatting": "node scripts/prettier.js check",
     "lint": "NODE_ENV=development eslint --max-warnings 0 .",
-    "start": "node server/bin/start.js",
+    "start": "node --use_strict server/bin/start.js",
     "start:development": "UPDATED_SCRIPT=start:development:server npm run deprecated-warning && npm run start:development:server",
     "start:development:client": "node client/scripts/start.js",
     "start:development:server": "NODE_ENV=development nodemon server/bin/start.js",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "flood-ui-kit": "^0.1.8",
     "flux": "^3.1.3",
     "fs-extra": "^5.0.0",
-    "geoip-lite": "^1.3.5",
+    "geoip-country": "^3.2.2",
     "html-webpack-plugin": "^4.0.0-beta.5",
     "joi": "^13.7.0",
     "jsonwebtoken": "^8.4.0",

--- a/server/util/clientResponseUtil.js
+++ b/server/util/clientResponseUtil.js
@@ -1,4 +1,4 @@
-const geoip = require('geoip-lite');
+const geoip = require('geoip-country');
 const truncateTo = require('./numberUtils');
 const torrentFilePropsMap = require('../../shared/constants/torrentFilePropsMap');
 const torrentPeerPropsMap = require('../../shared/constants/torrentPeerPropsMap');

--- a/server/util/scgiUtil.js
+++ b/server/util/scgiUtil.js
@@ -31,7 +31,7 @@ const methodCall = (connectionMethod, methodName, parameters) =>
 
     const headerLength = headerItems.reduce((accumulator, headerItem) => accumulator + headerItem.length, 0);
 
-    stream.write(`${headerLength}:${headerItems.join('')},${xml}`);
+    stream.end(`${headerLength}:${headerItems.join('')},${xml}`);
 
     bufferStream(stream)
       .then(data => {


### PR DESCRIPTION
## Description
uses geoip-country to avoid loading the ~100MB city files into memory (flood only uses it for the country flag)

forces strict mode on `npm start`

uses `end` rather than `write` for sending data to the server

## Related Issue
#812 

## Motivation and Context
Saves ~100MB of memory / thread

## How Has This Been Tested?
Tested on my seedbox

Tested by dumping node's memory with `gcore`. Changes now show less XML responses lingering around (GC seems to be more aggressive now) 

## Screenshots (if appropriate):
profiler showing memory usage of geoip-lite:
<img width="1230" alt="Screen Shot 2019-07-23 at 7 50 14 pm" src="https://user-images.githubusercontent.com/2100552/61705649-8ed59e80-ad89-11e9-9037-fc1d007b1f46.png">

profiler showing memory usage of geoip-country:
<img width="1285" alt="Screen Shot 2019-07-23 at 8 37 27 pm" src="https://user-images.githubusercontent.com/2100552/61705734-bc224c80-ad89-11e9-8154-e7aa6512cc9f.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
