### PR TITLE
Fix diskusage crash on unsupported platforms + add freebsd

### DIFF
--- a/server/services/diskUsageService.js
+++ b/server/services/diskUsageService.js
@@ -8,7 +8,8 @@ const execFile = util.promisify(require('child_process').execFile);
 const config = require('../../config');
 const diskUsageServiceEvents = require('../constants/diskUsageServiceEvents');
 
-const PLATFORMS_SUPPORTED = ['darwin', 'linux'];
+const PLATFORMS_SUPPORTED = ['darwin', 'linux', 'freebsd'];
+const MAX_BUFFER_SIZE = 65536;
 
 const filterMountPoint =
   config.diskUsageService && config.diskUsageService.watchMountPoints
@@ -17,30 +18,33 @@ const filterMountPoint =
       mountpoint => config.diskUsageService.watchMountPoints.includes(mountpoint)
     : () => true; // include all mounted file systems by default
 
+const linuxDfParsing = () =>
+  execFile('df | tail -n+2', {
+    shell: true,
+    maxBuffer: MAX_BUFFER_SIZE,
+  }).then(({stdout}) =>
+    stdout
+      .trim()
+      .split('\n')
+      .map(disk => disk.split(/\s+/))
+      .filter(disk => filterMountPoint(disk[5]))
+      .map(([_fs, size, used, avail, _pcent, target]) => {
+        return {
+          size: Number.parseInt(size, 10) * 1024,
+          used: Number.parseInt(used, 10) * 1024,
+          avail: Number.parseInt(avail, 10) * 1024,
+          target,
+        };
+      }),
+  );
+
 const diskUsage = {
-  linux: () =>
-    execFile('df | tail -n+2', {
-      shell: true,
-      maxBuffer: 4096,
-    }).then(({stdout}) =>
-      stdout
-        .trim()
-        .split('\n')
-        .map(disk => disk.split(/\s+/))
-        .filter(disk => filterMountPoint(disk[5]))
-        .map(([_fs, size, used, avail, _pcent, target]) => {
-          return {
-            size: Number.parseInt(size, 10) * 1024,
-            used: Number.parseInt(used, 10) * 1024,
-            avail: Number.parseInt(avail, 10) * 1024,
-            target,
-          };
-        }),
-    ),
+  linux: linuxDfParsing,
+  freebsd: linuxDfParsing,
   darwin: () =>
     execFile('df -kl | tail -n+2', {
       shell: true,
-      maxBuffer: 4096,
+      maxBuffer: MAX_BUFFER_SIZE,
     }).then(({stdout}) =>
       stdout
         .trim()

--- a/server/services/diskUsageService.js
+++ b/server/services/diskUsageService.js
@@ -56,8 +56,6 @@ const diskUsage = {
           };
         }),
     ),
-  // TODO:
-  win32: () => Promise.resolve([]),
 };
 
 const INTERVAL_UPDATE = 10000;
@@ -96,6 +94,9 @@ class DiskUsageService extends EventEmitter {
   }
 
   updateDisks() {
+    if (!PLATFORMS_SUPPORTED.includes(process.platform)) {
+      return Promise.resolve([]);
+    }
     return diskUsage[process.platform]().then(disks => {
       if (disks.length !== this.disks.length || disks.some((d, i) => d.used !== this.disks[i].used)) {
         this.tLastChange = Date.now();


### PR DESCRIPTION
When using flood on an unsupported platform, the app wasn't loading because of this exception:

```
GET /api/activity-stream?historySnapshot=fiveMin 200 1.189 ms - -
TypeError: diskUsage[process.platform] is not a function
    at DiskUsageService.updateDisks (/usr/home/inve1/flood/server/services/diskUsageService.js:99:39)
    at module.exports (/usr/home/inve1/flood/server/middleware/clientActivityStream.js:46:20)
    at Layer.handle [as handle_request] (/usr/home/inve1/flood/node_modules/express/lib/router/layer.js:95:5)
    at next (/usr/home/inve1/flood/node_modules/express/lib/router/route.js:137:13)
    at module.exports (/usr/home/inve1/flood/server/middleware/eventStream.js:26:3)
    at Layer.handle [as handle_request] (/usr/home/inve1/flood/node_modules/express/lib/router/layer.js:95:5)
    at next (/usr/home/inve1/flood/node_modules/express/lib/router/route.js:137:13)
    at Route.dispatch (/usr/home/inve1/flood/node_modules/express/lib/router/route.js:112:3)
    at Layer.handle [as handle_request] (/usr/home/inve1/flood/node_modules/express/lib/router/layer.js:95:5)
    at /usr/home/inve1/flood/node_modules/express/lib/router/index.js:281:22
```

## Description
I put in a check for supported platforms on that function. Since the freebsd df output is the same as linux I also added it as a supported platform with a small refactor

A note about the `maxBuffer` change: My df output is currently 31045 bytes long. In my case this is because of hundreds of rar2fs mounts to make rar downloads plex-friendly. Perhaps filtering filesystems like these before parsing them in node could be an option since the disk usage from these is useless. Don't want to handle this in a bugfix pr though.

## Motivation and Context
Flood stopped working on freebsd after I pulled master today 

## How Has This Been Tested?
Ran it on freebsd

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
