### PR TITLE
docker: allow `socketPath` from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,6 @@ I've been bad about cutting actual releases, so check this repo for recent commi
     * `FLOOD_SECRET`
     * `FLOOD_ENABLE_SSL`
 
-The docker container includes a volume at `/data`, which is where the database will be located.  Additionally, you can place your SSL files there, `/data/flood_ssl.key` and `/data/flood_ssl.cert`. Set `FLOOD_ENABLE_SSL` to `true` to enable their use if present. Additionally, a local rtorrent socket file located at `/data/rtorrent.sock` can be used if `RTORRENT_SOCK` is set to `true`.
+The docker container includes a volume at `/data`, which is where the database will be located.  Additionally, you can place your SSL files there, `/data/flood_ssl.key` and `/data/flood_ssl.cert`. Set `FLOOD_ENABLE_SSL` to `true` to enable their use if present. Additionally, a local rtorrent socket file located at `/data/rtorrent.sock` can be used if `RTORRENT_SOCK` is set to `true`. The location of the socket file can be overrided by setting `RTORRENT_SOCK_PATH` to the path of the socket.
 
 Check out the [Wiki](https://github.com/Flood-UI/flood/wiki/Docker) for more information.

--- a/config.docker.js
+++ b/config.docker.js
@@ -10,7 +10,7 @@ const CONFIG = {
     host: process.env.RTORRENT_SCGI_HOST || 'localhost',
     port: process.env.RTORRENT_SCGI_PORT || 5000,
     socket: process.env.RTORRENT_SOCK === 'true' || process.env.RTORRENT_SOCK === true,
-    socketPath: '/data/rtorrent.sock',
+    socketPath: process.env.RTORRENT_SOCK_PATH || '/data/rtorrent.sock',
   },
   ssl: process.env.FLOOD_ENABLE_SSL === 'true' || process.env.FLOOD_ENABLE_SSL === true,
   sslKey: '/data/flood_ssl.key',


### PR DESCRIPTION
## Description
Allow overriding the socketPath via an environment variable.

## Related Issue
#831 

## Motivation and Context
In my docker setup I have a common volume setup for the rtorrent socket that I add to all the containers. This allows using that without changing the socket name or creating a special volume just for flood.

## How Has This Been Tested?
Run container with `--env "RTORRENT_SOCK_PATH=/socket/rtorrent.scgi"`.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
