### PR TITLE
fix some spanish translations

### DIFF
--- a/client/src/javascript/i18n/es.js
+++ b/client/src/javascript/i18n/es.js
@@ -40,7 +40,7 @@ export default {
   'button.add': 'Agregar',
   'button.cancel': 'Cancelar',
   'button.no': 'No',
-  'button.save.feed': 'Gaurdar',
+  'button.save.feed': 'Guardar',
   'button.save': 'Guardar Configuración',
   'button.state.adding': 'Agregando...',
   'button.yes': 'Sí',
@@ -52,7 +52,7 @@ export default {
   'feeds.exclude.pattern': 'Patrón de Exclusión',
   'feeds.existing.feeds': 'Fuentes Existentes',
   'feeds.existing.rules': 'Reglas Existentes',
-  'feeds.label': 'Rotulo',
+  'feeds.label': 'Rótulo',
   'feeds.match.count': '{count, plural, =1 {# Encontrado} other {# Encontrados}}',
   'feeds.match.pattern': 'Patrón de Inclusión',
   'feeds.match': 'Encontrado',
@@ -109,7 +109,7 @@ export default {
 
   'mediainfo.execError':
     'Se ha encontrado un error al correr Mediainfo. Confirme que Mediainfo este instalado y disponible a Flood en el PATH',
-  'mediainfo.fetching': 'Fetching...',
+  'mediainfo.fetching': 'Obteniendo...',
   'mediainfo.heading': 'Mediainfo',
 
   'notification.torrent.finished.heading': 'Descarga Completada',
@@ -301,12 +301,12 @@ export default {
   'torrents.properties.upload.speed': 'Velocidad de Subida',
   'torrents.properties.upload.total': 'Cant. Subida',
 
-  'torrents.remove.are.you.sure': `Are you sure you want to remove {count, plural,
-      =0 {zero torrents}
+  'torrents.remove.are.you.sure': `¿Seguro que quiere eliminar {count, plural,
+      =0 {cero torrents}
       =1 {un torrent}
       other {# torrents}
     }?`,
-  'torrents.remove.delete.data': 'Delete data',
+  'torrents.remove.delete.data': 'Eliminar datos',
   'torrents.remove.error.no.torrents.selected': 'No ha seleccionado un torrent.',
   'torrents.remove': 'Eliminar Torrents',
 


### PR DESCRIPTION
Little change to fix some spanish translations

## Description

The following keys of the Spanish translation have been updated:
- `button.save.feed`
- `feeds.label`
- `mediainfo.fetching`
- `torrents.remove.are.you.sure`
- `torrents.remove.delete.data`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Fix some typos in translations and add missing translations

## How Has This Been Tested?
Launching the project and checking for the changed translations

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
