### PR TITLE
Hide docker mounts from diskusage by default

### DIFF
--- a/config.docker.js
+++ b/config.docker.js
@@ -15,6 +15,24 @@ const CONFIG = {
   ssl: process.env.FLOOD_ENABLE_SSL === 'true' || process.env.FLOOD_ENABLE_SSL === true,
   sslKey: '/data/flood_ssl.key',
   sslCert: '/data/flood_ssl.cert',
+  diskUsageService: {
+    dontWatchMountPoints: [
+      "/dev",
+      "/sys/fs/cgroup",
+      "/etc/resolv.conf",
+      "/etc/hostname",
+      "/etc/hosts",
+      "/dev/shm",
+      "/proc/asound",
+      "/proc/acpi",
+      "/proc/kcore",
+      "/proc/keys",
+      "/proc/timer_list",
+      "/proc/sched_debug",
+      "/proc/scsi",
+      "/sys/firmware",
+    ],
+  },
 };
 
 module.exports = CONFIG;

--- a/server/services/diskUsageService.js
+++ b/server/services/diskUsageService.js
@@ -11,12 +11,20 @@ const diskUsageServiceEvents = require('../constants/diskUsageServiceEvents');
 const PLATFORMS_SUPPORTED = ['darwin', 'linux', 'freebsd'];
 const MAX_BUFFER_SIZE = 65536;
 
-const filterMountPoint =
-  config.diskUsageService && config.diskUsageService.watchMountPoints
-    ? // if user has configured watchPartitions filter each line output for given
-      // array
-      mountpoint => config.diskUsageService.watchMountPoints.includes(mountpoint)
-    : () => true; // include all mounted file systems by default
+const filterMountPoint = mountpoint =>
+  {
+    // include all mounted file systems by default
+    if (!config.diskUsageService)
+      return true;
+    const {watchMountPoints, dontWatchMountPoints} = config.diskUsageService;
+    // whitelist
+    if (watchMountPoints)
+      return watchMountPoints.includes(mountpoint)
+    // blacklist
+    if (dontWatchMountPoints)
+      return !dontWatchMountPoints.includes(mountpoint)
+    return true;
+  }
 
 const linuxDfParsing = () =>
   execFile('df | tail -n+2', {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I think the docker related mount points should be hidden by default since they don't add any information. 

<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
before:
![before](https://i.imgur.com/eCfveSk.png)
after:
![after](https://i.imgur.com/hBqPmWc.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
