### PR TITLE
Handle faults returned from rtorrent

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,11 @@ I've been bad about cutting actual releases, so check this repo for recent commi
 ### Local Development
 
 1. Run `npm install`.
-2. Run `npm run start:development:server` and `npm run start:development:client` in separate terminal instances.
+2. Run `npm run build`.
+3. Run `npm run start:development:server` and `npm run start:development:client` in separate terminal instances.
     * `npm run start:development:server` uses [nodemon](https://github.com/remy/nodemon) to watch for changes to the server-side JavaScript.
     * `npm run start:development:client` watches for changes in the client-side source.
-3. Access the UI in your browser. Defaults to `localhost:4200`.
+4. Access the UI in your browser. Defaults to `localhost:4200`.
 
 ### Environment Variables
 

--- a/server/util/rTorrentDeserializer.js
+++ b/server/util/rTorrentDeserializer.js
@@ -71,6 +71,7 @@ const closeTag = elementName => {
     case 'data':
     case 'params':
     case 'param':
+    case 'fault':
     case 'member':
       break;
 


### PR DESCRIPTION
## Description
When rtorrent encounters an error interacting with the xmlrpc interface, it will return a response with a `<fault>...</fault>` tag in the response body. Currently Flood doesn't handle this tag in the rtorrentDeserializer. 

## Related Issue
#840

## Motivation and Context
Flood doesn't display the original error returned back from rtorrent, and any useful context that the original error message may provide is lost. 

## How Has This Been Tested?
Haven't tested it yet, just proposing changes. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
