### PR TITLE
Unescape Text nodes when deserializing

### DIFF
--- a/server/util/rTorrentDeserializer.js
+++ b/server/util/rTorrentDeserializer.js
@@ -1,5 +1,13 @@
 const saxen = require('saxen');
 
+const unescapeXMLString = value =>
+  value
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&apos;/g, "'")
+    .replace(/&quot;/g, '"');
+
 let stackMarks;
 let dataStack;
 let tmpData;
@@ -16,7 +24,7 @@ const openTag = elementName => {
 };
 
 const onText = value => {
-  tmpData.push(value);
+  tmpData.push(unescapeXMLString(value));
 };
 
 const onError = err => {


### PR DESCRIPTION
Downloading a finished torrent sometimes fails when any of the file paths contain an ampersand (&), it appears that the retrieved files from the system.multicall in `ClientRequest#getTorrentDetails` have escaped "&" to "&amp;". It appears to be the same with <, >, ", ' too.

## Description
I replace "&amp" with "&" on file paths, which fixes the bug on my end.
I also replace, &{lt,gt,apos,quot}; which should cover all escaped text node content according to these sources:
https://www.w3.org/TR/xml/#syntax
https://stackoverflow.com/questions/1091945/what-characters-do-i-need-to-escape-in-xml-documents

## How Has This Been Tested?
Tested on rtorrent 0.9.6

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
