### PR TITLE
Fix rate graph width on refresh of overview page

### DIFF
--- a/client/src/javascript/components/sidebar/TransferData.js
+++ b/client/src/javascript/components/sidebar/TransferData.js
@@ -61,13 +61,10 @@ class TransferData extends React.Component {
       <Measure
         offset
         onResize={contentRect => {
-          this.setState({sidebarWidth: contentRect.offset.width})
-        }}
-      >
-        {({ measureRef}) => (
-          <div
-            ref={measureRef}
-            className="client-stats__wrapper sidebar__item">
+          this.setState({sidebarWidth: contentRect.offset.width});
+        }}>
+        {({measureRef}) => (
+          <div ref={measureRef} className="client-stats__wrapper sidebar__item">
             <div
               className="client-stats"
               onMouseMove={this.handleMouseMove}

--- a/client/src/javascript/components/sidebar/TransferData.js
+++ b/client/src/javascript/components/sidebar/TransferData.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Measure from 'react-measure';
 
 import ClientStatusStore from '../../stores/ClientStatusStore';
 import connectStores from '../../util/connectStores';
@@ -11,16 +12,6 @@ class TransferData extends React.Component {
     graphInspectorPoint: null,
     sidebarWidth: 0,
   };
-
-  componentDidMount() {
-    const wrapperNode = this.wrapperRef;
-
-    if (wrapperNode != null) {
-      this.setState({
-        sidebarWidth: wrapperNode.offsetWidth,
-      });
-    }
-  }
 
   handleGraphHover = graphInspectorPoint => {
     this.setState({graphInspectorPoint});
@@ -67,20 +58,27 @@ class TransferData extends React.Component {
 
   render() {
     return (
-      <div
-        className="client-stats__wrapper sidebar__item"
-        ref={ref => {
-          this.wrapperRef = ref;
-        }}>
-        <div
-          className="client-stats"
-          onMouseMove={this.handleMouseMove}
-          onMouseOut={this.handleMouseOut}
-          onMouseOver={this.handleMouseOver}>
-          <TransferRateDetails inspectorPoint={this.state.graphInspectorPoint} />
-          {this.renderTransferRateGraph()}
-        </div>
-      </div>
+      <Measure
+        offset
+        onResize={contentRect => {
+          this.setState({sidebarWidth: contentRect.offset.width})
+        }}
+      >
+        {({ measureRef}) => (
+          <div
+            ref={measureRef}
+            className="client-stats__wrapper sidebar__item">
+            <div
+              className="client-stats"
+              onMouseMove={this.handleMouseMove}
+              onMouseOut={this.handleMouseOut}
+              onMouseOver={this.handleMouseOver}>
+              <TransferRateDetails inspectorPoint={this.state.graphInspectorPoint} />
+              {this.renderTransferRateGraph()}
+            </div>
+          </div>
+        )}
+      </Measure>
     );
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8714,6 +8714,11 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
     },
+    "get-node-dimensions": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-node-dimensions/-/get-node-dimensions-1.2.1.tgz",
+      "integrity": "sha512-2MSPMu7S1iOTL+BOa6K1S62hB2zUAYNF/lV0gSVlOaacd087lc6nR1H1r0e3B1CerTo+RceOmi1iJW+vp21xcQ=="
+    },
     "get-stdin": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -14400,6 +14405,17 @@
         "xtend": "^4.0.1"
       }
     },
+    "react-measure": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-measure/-/react-measure-2.3.0.tgz",
+      "integrity": "sha512-dwAvmiOeblj5Dvpnk8Jm7Q8B4THF/f1l1HtKVi0XDecsG6LXwGvzV5R1H32kq3TW6RW64OAf5aoQxpIgLa4z8A==",
+      "requires": {
+        "@babel/runtime": "^7.2.0",
+        "get-node-dimensions": "^1.2.1",
+        "prop-types": "^15.6.2",
+        "resize-observer-polyfill": "^1.5.0"
+      }
+    },
     "react-router": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.1.2.tgz",
@@ -15103,6 +15119,11 @@
       "requires": {
         "lodash": "^4.17.14"
       }
+    },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
       "version": "1.10.1",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "react-dropzone": "^4.3.0",
     "react-intl": "^2.9.0",
     "react-markdown": "^4.2.2",
+    "react-measure": "^2.3.0",
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",
     "react-transition-group": "^4.3.0",


### PR DESCRIPTION
## Description
The rate graph would not scale correctly after refreshing from the `/overview` page.
This was caused by the css loading after the `TransferData` component had mounted, which is when it checked its own size.
I have added `react-measure` to handle updating the scale whenever the sidebar changes width

## Related Issue
Issue #851 

## Motivation and Context
Fixes the rate graph scaling bug

## How Has This Been Tested?
Tested loading and refreshing from all routed URLs, verifying the graph is scaled correctly.
Confirmed running locally with development and production builds

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
