### PR TITLE
Add Hashing View

### DIFF
--- a/client/src/javascript/components/sidebar/StatusFilters.js
+++ b/client/src/javascript/components/sidebar/StatusFilters.js
@@ -11,6 +11,7 @@ import EventTypes from '../../constants/EventTypes';
 import Inactive from '../icons/Inactive';
 import SidebarFilter from './SidebarFilter';
 import StopIcon from '../icons/StopIcon';
+import HashIcon from '../icons/HashIcon';
 import TorrentFilterStore from '../../stores/TorrentFilterStore';
 import UIActions from '../../actions/UIActions';
 
@@ -39,6 +40,14 @@ class StatusFilters extends React.Component {
       },
       {
         label: this.props.intl.formatMessage({
+          id: 'filter.status.checking',
+          defaultMessage: 'Hashing',
+        }),
+        slug: 'checking',
+        icon: <HashIcon />,
+      },
+      {
+        label: this.props.intl.formatMessage({
           id: 'filter.status.completed',
           defaultMessage: 'Complete',
         }),
@@ -56,7 +65,7 @@ class StatusFilters extends React.Component {
       {
         label: this.props.intl.formatMessage({
           id: 'filter.status.active',
-          defaultMessage: 'All',
+          defaultMessage: 'Active',
         }),
         slug: 'active',
         icon: <Active />,

--- a/server/constants/torrentListPropMap.js
+++ b/server/constants/torrentListPropMap.js
@@ -54,8 +54,8 @@ torrentListPropMap.set('isComplete', {
 });
 
 torrentListPropMap.set('isHashChecking', {
-  methodCall: 'd.is_hash_checking=',
-  transformValue: booleanTransformer,
+  methodCall: 'd.hashing=',
+  transformValue: defaultTransformer,
 });
 
 torrentListPropMap.set('isOpen', {

--- a/server/services/torrentService.js
+++ b/server/services/torrentService.js
@@ -40,7 +40,7 @@ const getTorrentStatusFromDetails = torrentDetails => {
 
   const torrentStatus = [];
 
-  if (isHashChecking) {
+  if (isHashChecking !== '0') {
     torrentStatus.push(torrentStatusMap.checking);
   } else if (isComplete && isOpen && state === '1') {
     torrentStatus.push(torrentStatusMap.complete);

--- a/shared/util/formatUtil.js
+++ b/shared/util/formatUtil.js
@@ -38,7 +38,7 @@ const formatUtil = {
   status: (isHashChecking, isComplete, isOpen, uploadRate, downloadRate, state, message) => {
     const torrentStatus = [];
 
-    if (isHashChecking === '1') {
+    if (isHashChecking !== '0') {
       torrentStatus.push('ch'); // checking
     } else if (isComplete === '1' && isOpen === '1' && state === '1') {
       torrentStatus.push('sd'); // seeding


### PR DESCRIPTION
## Description
Adds a hashing view to flood. It changes the "isHashing" boolean from `d.is_hash_checking` to an enum based off `d.hashing` to correctly show torrents queued for hashing.

## Related Issue
#493

## Motivation and Context
Adds a Hashing view to Flood to match with the rTorrent view

## How Has This Been Tested?
Tested on my setup (see screenshot below)

## Screenshots (if appropriate):
![Screen Shot 2020-03-17 at 3 58 35 pm](https://user-images.githubusercontent.com/2100552/76823387-35663680-6868-11ea-97d2-6afc11cd6a49.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
