### PR TITLE
Update Dockerfile to handle FLOOD_BASE_URI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 ARG NODE_IMAGE=node:12.2-alpine
 ARG WORKDIR=/usr/src/app/
+ARG FLOOD_BASE_URI=/
 
 FROM ${NODE_IMAGE} as nodebuild
-ARG WORKDIR
 
+ARG WORKDIR
 WORKDIR $WORKDIR
+ARG FLOOD_BASE_URI
+ENV FLOOD_BASE_URI $FLOOD_BASE_URI
 
 # Generate node_modules
 COPY package.json \
@@ -31,9 +34,11 @@ RUN npm run build && \
 
 # Now get the clean image without any dependencies and copy compiled app
 FROM ${NODE_IMAGE} as flood
-ARG WORKDIR
 
+ARG WORKDIR
 WORKDIR $WORKDIR
+ARG FLOOD_BASE_URI
+ENV FLOOD_BASE_URI $FLOOD_BASE_URI
 
 # Install runtime dependencies.
 RUN apk --no-cache add \


### PR DESCRIPTION
## Description
This PR updates Dockerfile to correctly handle FLOOD_BASE_URI environment variable. 

Unlike other environment variables in [config.docker.js](https://github.com/Flood-UI/flood/blob/master/config.docker.js), FLOOD_BASE_URI must be used during `docker build`, not only `docker run`. 

To enable this I added an ARG which can be passed to docker-build:

```bash
docker build --build-arg FLOOD_BASE_URI='/flood' -t flood .
```

or if using docker-compose:

```yaml
...
services: 
    flood:
        image: flood
        build: 
            context: '.'
            args: 
                FLOOD_BASE_URI: '/flood'
        ...
```

Note that FLOOD_BASE_URI does not need to be passed to docker-run.

FLOOD_BASE_URI variable is set in both "build" and "release" images which are part of Dockerfile.

## Related Issue
Fixes #621 

## Context
These changes have been partially implemented in PR #837 but this PR is smaller in scope and contains only a non-breaking change. 

## How Has This Been Tested?
See commands above

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation. — Wiki needs to be updated when this is merged.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
