### PR TITLE
Added 'Last Transfer' date in torrents details: list, modal, UI column settings

### DIFF
--- a/client/src/javascript/components/modals/torrent-details-modal/TorrentGeneralInfo.js
+++ b/client/src/javascript/components/modals/torrent-details-modal/TorrentGeneralInfo.js
@@ -25,6 +25,11 @@ class TorrentGeneralInfo extends React.Component {
       creation = new Date(torrent.creationDate * 1000);
     }
 
+    let lastTransfer = null;
+    if (torrent.lastTransfer) {
+      lastTransfer = new Date(torrent.lastTransfer * 1000);
+    }
+
     const VALUE_NOT_AVAILABLE = (
       <span className="not-available">
         <FormattedMessage id="torrents.details.general.none" defaultMessage="None" />
@@ -128,6 +133,20 @@ class TorrentGeneralInfo extends React.Component {
                     total: <FormattedNumber value={torrent.seedsTotal} />,
                   }}
                 />
+              </td>
+            </tr>
+            <tr className="torrent-details__detail torrent-details__detail--lastTransfer">
+              <td className="torrent-details__detail__label">
+                <FormattedMessage id="torrents.details.general.last_xfer" defaultMessage="Last Transfer" />
+              </td>
+              <td className="torrent-details__detail__value">
+                {lastTransfer
+                  ? `${this.props.intl.formatDate(lastTransfer, {
+                      year: 'numeric',
+                      month: 'long',
+                      day: '2-digit',
+                    })} ${this.props.intl.formatTime(lastTransfer)}`
+                  : VALUE_NOT_AVAILABLE}
               </td>
             </tr>
             <tr className="torrent-details__table__heading">

--- a/client/src/javascript/components/torrent-list/SortDropdown.js
+++ b/client/src/javascript/components/torrent-list/SortDropdown.js
@@ -16,6 +16,7 @@ const SORT_PROPERTIES = [
   'upTotal',
   'sizeBytes',
   'dateAdded',
+  'lastTransfer',
 ];
 
 class SortDropdown extends React.Component {

--- a/client/src/javascript/components/torrent-list/TorrentDetail.js
+++ b/client/src/javascript/components/torrent-list/TorrentDetail.js
@@ -31,6 +31,7 @@ const icons = {
   basePath: <FolderClosedSolid />,
   hash: <HashIcon />,
   dateAdded: <CalendarIcon />,
+  lastTransfer: <CalendarIcon />,
   dateCreated: <CalendarCreatedIcon />,
   isPrivate: <LockIcon />,
   message: <TrackerMessageIcon />,
@@ -43,8 +44,8 @@ const icons = {
   upTotal: <UploadThickIcon />,
 };
 
-const booleanRenderer = value => (value ? icons.checkmark : null);
-const dateRenderer = date => <FormattedDate value={date * 1000} />;
+const booleanRenderer = (value) => (value ? icons.checkmark : null);
+const dateRenderer = (date) => (date ? <FormattedDate value={date * 1000} /> : null);
 const peersRenderer = (peersConnected, totalPeers) => (
   <FormattedMessage
     id="torrent.list.peers"
@@ -66,6 +67,7 @@ const sizeRenderer = value => <Size value={value} />;
 const transformers = {
   dateAdded: dateRenderer,
   dateCreated: dateRenderer,
+  lastTransfer: dateRenderer,
   downRate: speedRenderer,
   downTotal: sizeRenderer,
   ignoreScheduler: booleanRenderer,

--- a/client/src/javascript/constants/TorrentProperties.js
+++ b/client/src/javascript/constants/TorrentProperties.js
@@ -83,6 +83,10 @@ const torrentProperties = {
     id: 'torrents.properties.trackers',
     defaultMessage: 'Trackers',
   },
+  lastTransfer: {
+    id: 'torrents.properties.last_xfer',
+    defaultMessage: 'Last Transfer',
+  },
 };
 
 export default torrentProperties;

--- a/client/src/javascript/stores/SettingsStore.js
+++ b/client/src/javascript/stores/SettingsStore.js
@@ -39,6 +39,7 @@ class SettingsStoreClass extends BaseStore {
         {id: 'seeds', visible: true},
         {id: 'dateAdded', visible: true},
         {id: 'dateCreated', visible: false},
+        {id: 'lastTransfer', visible: false},
         {id: 'basePath', visible: false},
         {id: 'comment', visible: false},
         {id: 'hash', visible: false},

--- a/server/constants/torrentListPropMap.js
+++ b/server/constants/torrentListPropMap.js
@@ -143,6 +143,11 @@ torrentListPropMap.set('dateCreated', {
   transformValue: dateTransformer,
 });
 
+torrentListPropMap.set('lastTransfer', {
+  methodCall: 'd.custom=last_xfer',
+  transformValue: dateTransformer,
+});
+
 torrentListPropMap.set('throttleName', {
   methodCall: 'd.throttle_name=',
   transformValue: defaultTransformer,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added 'Last Transfer' date in torrents details: list, modal, UI column settings

Note: Requires rTorrent configuration to save d.custom.last_xfer:

```
## SCHEDULE: Set "last_xfer" custom timestamp field for items that transfer data
method.insert.value = pyro.last_xfer.min_rate, 5000

method.insert = pyro._last_xfer_check_min_rate, simple|private,\
    "greater=argument.0=,pyro.last_xfer.min_rate="
method.insert = pyro._last_xfer_update, simple|private,\
    "d.custom.set=last_xfer,$cat=$system.time= ; branch=argument.0=,d.save_resume="
method.insert = d.last_xfer.is_active, simple,\
    "or={pyro._last_xfer_check_min_rate=$d.up.rate=,pyro._last_xfer_check_min_rate=$d.down.rate=}"
method.insert = d.timestamp.last_xfer, simple, "if=$d.last_xfer.is_active=,$cat=$system.time=,$d.custom=last_xfer"

schedule2 = pyro_update_last_xfer, 33, 17,\
    "d.multicall2=active,\"branch=$d.last_xfer.is_active=,pyro._last_xfer_update=\""
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I wanted to be able to identify torrents which had no activity for a while, to remove them first.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Used Flood with this change for months...

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/370329/90015972-54ca8980-dc77-11ea-8cf7-c0c0532a7dd6.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
